### PR TITLE
Add basic Open Graph meta tags

### DIFF
--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -18,6 +18,17 @@ module.exports = {
     shortName: 'MU',
     startUrl: '.',
   },
+  openGraph: {
+    image: 'https://res.cloudinary.com/ooloth/image/upload/c_scale,w_1200,f_auto,q_auto/v1645057009/mu/michael-landscape.jpg',
+    locale: 'en_CA',
+    twitter: {
+      card: 'summary_large_image',
+      creator: '@ooloth',
+      site: '@ooloth',
+    },
+    type: 'website',
+
+  },
   title: 'Michael Uloth',
   url: 'https://michaeluloth.com/',
 };

--- a/src/_data/site.js
+++ b/src/_data/site.js
@@ -19,7 +19,8 @@ module.exports = {
     startUrl: '.',
   },
   openGraph: {
-    image: 'https://res.cloudinary.com/ooloth/image/upload/c_scale,w_1200,f_auto,q_auto/v1645057009/mu/michael-landscape.jpg',
+    image:
+      'https://res.cloudinary.com/ooloth/image/upload/c_scale,w_1200,f_auto,q_auto/v1645057009/mu/michael-landscape.jpg',
     locale: 'en_CA',
     twitter: {
       card: 'summary_large_image',
@@ -27,7 +28,6 @@ module.exports = {
       site: '@ooloth',
     },
     type: 'website',
-
   },
   title: 'Michael Uloth',
   url: 'https://michaeluloth.com/',

--- a/src/_includes/layouts/root.webc
+++ b/src/_includes/layouts/root.webc
@@ -8,7 +8,23 @@
 
     <!--- SEO --->
     <title @text="title || $data.site.title"></title>
-    <meta name="description" :content="description || $data.site.description" />
+    <meta name="description" :content="description || $data.site.description.site" />
+    <link rel="canonical" href="https://michaeluloth.com" />
+
+    <!--- Open Graph --->
+    <!--- see: https://ogp.me --->
+    <meta property="og:title" :content="title || $data.site.title" />
+    <script webc:type="js" webc:is="template">
+      `<meta property="og:url" content="${require('path').join(site.url, page.url)}" />`;
+    </script>
+    <meta property="og:description" :content="description || $data.site.description.site" />
+    <meta name="twitter:card" :content="$data.site.openGraph.twitter.card" />
+    <meta name="twitter:creator" :content="$data.site.openGraph.twitter.creator" />
+    <meta name="twitter:site" :content="$data.site.openGraph.twitter.site" />
+    <meta property="og:type" :content="$data.site.openGraph.type" />
+    <meta property="og:image" :content="ogImage || $data.site.openGraph.image" />
+    <meta property="og:locale" :content="$data.site.openGraph.locale" />
+    <meta property="og:site_name" :content="$data.site.title" />
 
     <!--- Icons --->
     <!--- see: https://developer.mozilla.org/en-US/docs/Learn/HTML/Introduction_to_HTML/The_head_metadata_in_HTML#adding_custom_icons_to_your_site --->


### PR DESCRIPTION
## ✅ What

- Adds basic Open Graph meta tags
- Includes a fallback image for pages that don't provide a custom one

_Doesn't handle constructing Cloudinary URLs from image names yet. Progress over perfection._

## 🤔 Why

- Meta tags are key for social sharing links looking good and containing useful content!
