### PR TITLE
Build OG images with Cloudinary

### DIFF
--- a/src/_includes/layouts/root.webc
+++ b/src/_includes/layouts/root.webc
@@ -25,8 +25,29 @@
     <meta property="og:locale" :content="$data.site.openGraph.locale" />
     <meta property="og:site_name" :content="$data.site.title" />
     <script webc:type="js" webc:is="template">
-      const pathAndExtension = ogImage || $data.site.openGraph.image;
-      const imageUrl = `https://res.cloudinary.com/ooloth/image/upload/c_scale,w_1200,f_auto,q_auto/${pathAndExtension}`;
+      if (!title && !private && !eleventyExcludeFromCollections && page.url !== '/' && page.url !== '/404.html') {
+        throw new Error(`No title for ${page.url}`);
+      }
+
+      // see: https://cloudinary.com/documentation/transformation_reference
+      const imageUrl = [
+        `https://res.cloudinary.com/${process.env.CLOUDINARY_CLOUD_NAME}/image/upload`,
+        'c_fit,w_1200,h_630,f_auto,q_auto',
+        // see: https://cloudinary.com/documentation/transformation_reference#e_colorize
+        'e_colorize,co_rgb:171717',
+        // see: https://cloudinary.com/cookbook/add_a_border_to_images
+        'bo_24px_solid_rgb:fda4af,b_rgb:000000,fl_relative',
+        // see: https://cloudinary.com/cookbook/overlaying_social_profile_pictures_on_top_of_images
+        'l_twitter_name:ooloth.png,w_120,r_max,g_south_east,x_64,y_64',
+        // see: https://cloudinary.com/documentation/layers#text_overlays
+        `c_fit,l_text:Helvetica_100_extrabold_line_spacing_4:${
+          title || $data.site.title
+        },co_rgb:fafafa,g_west,x_80,y_-60,w_1040,h_480`,
+        `c_fit,l_text:Helvetica_42_bold:${$data.site.title},co_rgb:fafafa,g_south_west,x_80,y_118,w_900`,
+        // see: https://support.cloudinary.com/hc/en-us/articles/202521512-How-to-add-a-special-characters-in-text-overlays-
+        `c_fit,l_text:Helvetica_36:%252F${page.fileSlug}%252F,co_rgb:fafafa,g_south_west,x_72,y_64,w_900`,
+        'mu/blank.png',
+      ].join('/');
       `<meta property="og:image" content="${imageUrl}" />`;
     </script>
 

--- a/src/index.webc
+++ b/src/index.webc
@@ -1,6 +1,5 @@
 ---
 layout: main.webc
-description: todo
 ---
 
 <h1 class="sr-only">Michael Uloth</h1>

--- a/src/likes.webc
+++ b/src/likes.webc
@@ -2,6 +2,7 @@
 layout: main.webc
 # TODO: remove this line when publishing
 eleventyExcludeFromCollections: true
+title: Likes
 ---
 
 <h1>Likes</h1>

--- a/src/notes.webc
+++ b/src/notes.webc
@@ -1,5 +1,6 @@
 ---
 layout: main.webc
+title: Notes
 ---
 
 <h1 class="sr-only">Notes</h1>


### PR DESCRIPTION
## ✅ What

- Constructs Open Graph images using Cloudinary's URL API

## 🤔 Why

- No more hunting for images in Unsplash just to publish a post!
- Solves the problem of what OG image to use for `/notes` pages
- Much better than using my headshot as the main social sharing photo
